### PR TITLE
Build in Firebot.sh instead of calling a middleman script.

### DIFF
--- a/Firebot/firebot.sh
+++ b/Firebot/firebot.sh
@@ -288,8 +288,9 @@ build_inspect_fds()
 {
    # build an openmp thread checker version of fds
    echo "      inspection"
-   cd $fdsrepo/Verification/Thread_Check/
-   ./build_inspect_openmp.sh -I  &> $OUTPUT_DIR/stage2a
+   cd $fdsrepo/Build/${INTEL}mpi_intel_linux_64_inspect
+   make -f ../makefile clean &> /dev/null
+   ./make_fds.sh &> $OUTPUT_DIR/stage2a
 }
 
 #---------------------------------------------


### PR DESCRIPTION
Building in firebot itself, thus allowing for removal of a script from FDS proper.