### PR TITLE
Ensure correct file is scanned for errors

### DIFF
--- a/Firebot/firebot.sh
+++ b/Firebot/firebot.sh
@@ -675,7 +675,7 @@ check_cases_release()
       [[ `grep -rI 'STOP: Numerical' *` == "" ]] && \
       [[ `grep -rI forrtl *` == "" ]] && \
       [[ `grep 'BAD TERMINATION'  */*.log` == "" ]] && \
-      [[ `grep 'Inspector Clean' $OUTPUT_DIR/stage5` != "" ]]
+      [[ `grep 'Inspector Clean' $OUTPUT_DIR/stage5i` != "" ]]
    then
       cases_release_success=true
    else


### PR DESCRIPTION
While monitoring Firebot, noted a blank error. Decided to check conditionals, and found a missing 'i.' With its addition, the next Firebot run should have nothing to complain about. 