### PR TITLE
bots: correrct revision computation (because of '-' in tag now)

### DIFF
--- a/Firebot/firebot.sh
+++ b/Firebot/firebot.sh
@@ -270,7 +270,7 @@ get_fds_revision()
    if [ "$subrev" == "" ]; then
      git describe --abbrev | awk -F '-' '{print $1"-0"}' > $LATESTAPPS_DIR/FDS_REVISION
    else
-     git describe --abbrev | awk -F '-' '{print $1"-"$2}' > $LATESTAPPS_DIR/FDS_REVISION
+     git describe --abbrev | awk -F '-' '{print $1"-"$2"-"$3}' > $LATESTAPPS_DIR/FDS_REVISION
    fi
    FDS_SHORTHASH=`git rev-parse --short HEAD`
    echo $FDS_SHORTHASH > $LATESTAPPS_DIR/FDS_HASH

--- a/Smokebot/smokebot.sh
+++ b/Smokebot/smokebot.sh
@@ -2027,7 +2027,7 @@ subrev=`git describe --abbrev | awk -F '-' '{print $2}'`
 if [ "$subrev" == "" ]; then
   git describe --abbrev | awk -F '-' '{print $1"-0"}' > $LATESTAPPS_DIR/SMV_REVISION
 else
-  git describe --abbrev | awk -F '-' '{print $1"-"$2}' > $LATESTAPPS_DIR/SMV_REVISION
+  git describe --abbrev | awk -F '-' '{print $1"-"$2"-"$3}' > $LATESTAPPS_DIR/SMV_REVISION
 fi
 git rev-parse --short HEAD > $LATESTAPPS_DIR/SMV_HASH
 


### PR DESCRIPTION
note, apps in last night's nightly bundle appear to be built with the correct revsion.  The bug I'm correcting fixes the bundle name. 