### PR TITLE
add a script for checking whether extensions used by FDS and smokeview are documented in the FDS user's guide

### DIFF
--- a/Firebot/check_exts.sh
+++ b/Firebot/check_exts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+REPOROOT=~firebot/FireModels_clone
+FROMDIR=$REPOROOT/fds/Verification/Complex_Geometry
+EXT_DIR=output/ext_fds_dir
+EXT_DOC=output/ext_fds_doc
+GIT_OUT=output/gitout
+FDSUG=$REPOROOT/fds/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+ls -l $FROMDIR | sed 1,1d - | grep -v drwx | awk '{print $NF}' | awk -F'.' '{print $NF}' | sort -u > $EXT_DIR
+grep -E 'fdsext|smvext|qfdsext|ignoreext' $FDSUG | awk '{print $NF}' | sort -u > $EXT_DOC
+git diff --no-index $EXT_DIR  $EXT_DOC > $GIT_OUT
+ndoc=`grep ^- $GIT_OUT | sed 's/^-//g'  | grep -v  output | wc -l`
+if [ $ndoc -gt 0 ]; then
+  echo The following extentions are not documented
+  grep ^- $GIT_OUT | sed 's/^-//g'  | grep -v  output
+else
+  echo All extensions found in the directory $FROMDIR
+  echo were found in %fdsext, %smvext or %qfdsext lines in the document:
+  echo $FDSUG
+fi
+ndir=`grep ^+ $GIT_OUT | sed 's/^+//g'  | grep -v  output | wc -l`
+if [ $ndir -gt 0 ]; then
+  echo the following extensions are documented but not found in $FROMDIR
+  grep ^+ $GIT_OUT | sed 's/^+//g'  | grep -v  output
+fi

--- a/Firebot/check_exts.sh
+++ b/Firebot/check_exts.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# this script is a prototype for identifying file extensiions not documented in the FDS user's guide
+# for now the input directory is hard wired to the fds Complex_Geometry  Verification directory
+# with the firebot account.  This script will be made more general after file extensions identified now
+# are documented.
+
 REPOROOT=~firebot/FireModels_clone
 FROMDIR=$REPOROOT/fds/Verification/Complex_Geometry
 EXT_DIR=output/ext_fds_dir


### PR DESCRIPTION
this script for now is "rough" it looks at file extensions created in the Complex_Geometry directory by a blaze firebot run.  once the table it checks in the FDS user's guide is more refined, I'll improve the script