### PR TITLE
Firebot: add PYTHONPATH to setup script

### DIFF
--- a/Firebot/setup_python3.sh
+++ b/Firebot/setup_python3.sh
@@ -14,6 +14,7 @@ else
   python3 -m venv fds_python_env
   source fds_python_env/bin/activate
   pip install -r requirements.txt
+  export PYTHONPATH=$reporoot/fds/Utilities/Python:$PYTHONPATH
   cd $reporoot/fds/Utilities/Python
   python hello_world.py
   cd $curdir


### PR DESCRIPTION
This is needed so that firebot's python scripts will see fdsplotlib.  In your own system add
```
# add PYTHONPATH for FDS scripts
export PYTHONPATH=$FIREMODELS/fds/Utilities/Python:$PYTHONPATH
```