### PR TITLE
cfastbot: remove error and warning logs before running cfastbot

### DIFF
--- a/Cfastbot/cfastbot.sh
+++ b/Cfastbot/cfastbot.sh
@@ -801,6 +801,11 @@ WARNING_LOG=$OUTPUT_DIR/warnings
 NEWGUIDE_DIR=$OUTPUT_DIR/NEW_GUIDES
 VALIDATION_STATS_LOG=$OUTPUT_DIR/statistics
 
+#*** remove warning and error logs from a previous cfastbot run
+
+rm -f $WARNING_LOG
+rm -f $ERROR_LOG
+
 echo ""
 echo "Settings"
 echo "--------"


### PR DESCRIPTION
if a previous cfastbot run had errors or warnings and the current cfastbot run did not - a false positive would be reported because the warning and error logs were not being removed